### PR TITLE
Use enableCompileCache

### DIFF
--- a/.changeset/afraid-rivers-talk.md
+++ b/.changeset/afraid-rivers-talk.md
@@ -1,5 +1,5 @@
 ---
-"hereby": patch
+"hereby": minor
 ---
 
 Use enableCompileCache

--- a/.changeset/afraid-rivers-talk.md
+++ b/.changeset/afraid-rivers-talk.md
@@ -1,0 +1,5 @@
+---
+"hereby": patch
+---
+
+Use enableCompileCache

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,14 @@
-import { main } from "./cli/index.js";
-import { real } from "./cli/utils.js";
+import module from "node:module";
+
+declare module "node:module" {
+    export const enableCompileCache: (() => void) | undefined;
+}
+
+module.enableCompileCache?.();
 
 async function run() {
+    const { main } = await import("./cli/index.js");
+    const { real } = await import("./cli/utils.js");
     await main(await real());
 }
 


### PR DESCRIPTION
Saves a little bit of time at startup. More interesting when loading larger Herebyfiles and deps.