### PR TITLE
Allow typescript herebyfiles

### DIFF
--- a/.changeset/six-regions-clean.md
+++ b/.changeset/six-regions-clean.md
@@ -1,0 +1,5 @@
+---
+"hereby": minor
+---
+
+Support typescript herebyfiles (in runtimes that support typescript)

--- a/src/__tests__/cli/loadHerebyfile.test.ts
+++ b/src/__tests__/cli/loadHerebyfile.test.ts
@@ -108,6 +108,31 @@ test("findHerebyfile", async (t) => {
     });
 });
 
+for (
+    const name of [
+        // javascript
+        "Herebyfile.mjs",
+        "Herebyfile.js",
+
+        // typescript
+        "Herebyfile.ts",
+        "Herebyfile.mts",
+
+        // case insensitive
+        "herebyfile.mts",
+    ]
+) {
+    test(`finds ${name}`, async (t) => {
+        const tmpdir = tmp.dirSync({ unsafeCleanup: true });
+        t.teardown(tmpdir.removeCallback);
+        const dir = tmpdir.name;
+        const expectedHerebyFile = path.join(dir, name);
+
+        await fs.promises.writeFile(expectedHerebyFile, "export {}");
+        t.is(findHerebyfile(dir), expectedHerebyFile);
+    });
+}
+
 test("cycle", async (t) => {
     const herebyfilePath = path.join(fixturesPath, "cycle.mjs");
 

--- a/src/cli/loadHerebyfile.ts
+++ b/src/cli/loadHerebyfile.ts
@@ -7,7 +7,7 @@ import pc from "picocolors";
 import { Task } from "../index.js";
 import { findUp, UserError } from "./utils.js";
 
-const herebyfileRegExp = /^herebyfile\.m?js$/i;
+const herebyfileRegExp = /^herebyfile\.m?[jt]s$/i;
 
 export function findHerebyfile(dir: string): string {
     const result = findUp(dir, (dir) => {


### PR DESCRIPTION
Node >=23 is able to execute typescript files (provided they avoid some typescript features) so it's possible to write Herebyfiles in typescript with no additional tooling, if you configure the --herebyfile option.

```
hereby --herebyfile Herebyfile.mts
```

This change allows hereby to find ts files by default.